### PR TITLE
Put inline script in a separate file

### DIFF
--- a/background.html
+++ b/background.html
@@ -3,11 +3,7 @@
 	<script src="asana.js"></script>
 	<script src="api_bridge.js"></script>
 	<script src="extension_server.js"></script>
-    <script src="options.js"></script>
-	<script>
-
-    Asana.ExtensionServer.listen();
-
-  </script>
+	<script src="options.js"></script>
+	<script src="background.js"></script>
 </head>
 </html>

--- a/background.js
+++ b/background.js
@@ -1,0 +1,1 @@
+Asana.ExtensionServer.listen();


### PR DESCRIPTION
Problem:
Inline JavaScript in `background.html` is not being executed.

Cause:
This is because of the [Content Security Policy](http://developer.chrome.com/trunk/extensions/contentSecurityPolicy.html#JSExecution) adopted by Chrome's extension system. This restriction [cannot be relaxed](http://developer.chrome.com/trunk/extensions/contentSecurityPolicy.html#relaxing-inline-script).

Fix:
This patch externalizes the JavaScript code found in `background.html` to a file called `background.js`.
