### PR TITLE
Prevents duplicate click handlers on the button.

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -258,6 +258,8 @@ Popup = {
     if (enabled) {
       // Update appearance and add handlers.
       button.removeClass("is-disabled");
+      button.unbind("click");
+      button.unbind("keydown");
       button.click(function() {
         me.createTask();
         return false;
@@ -270,8 +272,8 @@ Popup = {
     } else {
       // Update appearance and remove handlers.
       button.addClass("is-disabled");
-      button.unbind('click');
-      button.unbind('keydown');
+      button.unbind("click");
+      button.unbind("keydown");
     }
   },
 


### PR DESCRIPTION
Every time the workspace is changed a new click handler was added to the Add-Task button.  They were only removed if the button became disabled, but switching workspaces doesn't disable the button.

This just clears the existing handlers before adding one.